### PR TITLE
Use Val as an actual value

### DIFF
--- a/examples/heatmap.jl
+++ b/examples/heatmap.jl
@@ -25,13 +25,13 @@ function plots()
                         anchor_top = (rootwin, :top, 0),
                         anchor_right = (rootwin, :right, 0),
                         anchor_bottom = (rootwin, :bottom, 0))
-    con = create_widget(Val{:container}, win)
+    con = create_widget(Val(:container), win)
 
-    func = create_widget(Val{:form}, con, ["Function f(x,y) ="], borders = true,
+    func = create_widget(Val(:form), con, ["Function f(x,y) ="], borders = true,
                          anchor_left = (win, :left, 1),
                          anchor_top  = (win, :top,  0))
 
-    label = create_widget(Val{:label}, con,
+    label = create_widget(Val(:label), con,
                           anchor_left  = (func, :left,   0),
                           anchor_right = (func, :right,  0),
                           anchor_top   = (func, :bottom, 2),
@@ -40,7 +40,7 @@ function plots()
                           fill_color   = true,
                           text = "Setup limits")
 
-    xlim = create_widget(Val{:form}, con, ["x min.", "x max."],
+    xlim = create_widget(Val(:form), con, ["x min.", "x max."],
                          anchor_left   = (func,  :left,    0),
                          anchor_top    = (label, :bottom,  0),
                          anchor_right  = (func,  :center, -1),
@@ -48,7 +48,7 @@ function plots()
                          color_invalid = c3,
                          validator     = Float64)
 
-    ylim = create_widget(Val{:form}, con, ["y min.", "y max."],
+    ylim = create_widget(Val(:form), con, ["y min.", "y max."],
                          anchor_left   = (func,  :center, +1),
                          anchor_top    = (label, :bottom,  0),
                          anchor_right  = (func,  :right,   0),
@@ -56,7 +56,7 @@ function plots()
                          color_invalid = c3,
                          validator     = Float64)
 
-    label = create_widget(Val{:label}, con,
+    label = create_widget(Val(:label), con,
                           anchor_left  = (func, :left,   0),
                           anchor_right = (func, :right,  0),
                           anchor_top   = (ylim, :bottom, 2),
@@ -82,7 +82,7 @@ function plots()
     rb = nothing
 
     for i = 1:length(colormap_keys)
-        rb = create_widget(Val{:radio_button}, con,
+        rb = create_widget(Val(:radio_button), con,
                            group_name      = "Colormap",
                            label           = colormap_keys[i],
                            anchor_left     = (lanchor_w, lanchor_a, 0),
@@ -104,7 +104,7 @@ function plots()
         end
     end
 
-    bplot = create_widget(Val{:button}, con,
+    bplot = create_widget(Val(:button), con,
                           label           = "Plot",
                           anchor_left     = (func, :left,   0),
                           anchor_top      = (rb  , :bottom, 3),
@@ -112,7 +112,7 @@ function plots()
                           width           = 14,
                           color_highlight = c2)
 
-    bcplt = create_widget(Val{:button}, con,
+    bcplt = create_widget(Val(:button), con,
                           label             = "Clear plot",
                           anchor_center     = (func, :center, 0),
                           anchor_top        = (rb  , :bottom, 3),
@@ -120,7 +120,7 @@ function plots()
                           width             = 14,
                           color_highlight   = c2)
 
-    bcfor = create_widget(Val{:button}, con,
+    bcfor = create_widget(Val(:button), con,
                           label           = "Clear form",
                           anchor_right    = (func, :right,  0),
                           anchor_top      = (rb  , :bottom, 3),
@@ -128,7 +128,7 @@ function plots()
                           width           = 14,
                           color_highlight = c2)
 
-    tplot  = create_widget(Val{:label}, con,
+    tplot  = create_widget(Val(:label), con,
                            anchor_left    = (con, :center, 0),
                            anchor_right   = (con, :right,  0),
                            anchor_top     = (con, :top,    1),
@@ -138,7 +138,7 @@ function plots()
                            alignment      = :c)
 
     str    = create_plot(zeros(40,40), get_limits(xlim,ylim)...)
-    canvas = create_widget(Val{:ansi_label}, con, text = str,
+    canvas = create_widget(Val(:ansi_label), con, text = str,
                            anchor_left    = (tplot, :left,   0),
                            anchor_right   = (tplot, :right,  0),
                            anchor_top     = (tplot, :bottom, 1),
@@ -233,4 +233,3 @@ function get_limits(xlim,ylim)
 end
 
 plots()
-

--- a/examples/old/forms.jl
+++ b/examples/old/forms.jl
@@ -3,9 +3,9 @@ using SatelliteToolbox
 using TextUserInterfaces
 using UnicodePlots
 
-const propagators = Dict("J2"       => Val{:J2},
-                         "J4"       => Val{:J4},
-                         "Two Body" => Val{:twobody})
+const propagators = Dict("J2"       => Val(:J2),
+                         "J4"       => Val(:J4),
+                         "Two Body" => Val(:twobody))
 
 function satellite_ground_trace()
 
@@ -96,13 +96,13 @@ function satellite_ground_trace()
     form = create_form(fields)
 
     # Set field types.
-    set_field_type(form, "a",    Val{:numeric}, 2, 6400, typemax(Int))
-    set_field_type(form, "e",    Val{:numeric}, 6,    0, 1-eps())
-    set_field_type(form, "i",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "Ω",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "ω",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "f",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "prop", Val{:enum},    ["J2", "J4", "Two Body"])
+    set_field_type(form, "a",    Val(:numeric), 2, 6400, typemax(Int))
+    set_field_type(form, "e",    Val(:numeric), 6,    0, 1-eps())
+    set_field_type(form, "i",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "Ω",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "ω",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "f",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "prop", Val(:enum),    ["J2", "J4", "Two Body"])
 
     set_form_win(form, win_inputs)
 

--- a/examples/old/menus_and_forms.jl
+++ b/examples/old/menus_and_forms.jl
@@ -4,9 +4,9 @@ using SatelliteToolbox
 using UnicodePlots
 using TextUserInterfaces
 
-const propagators = Dict("J2"       => Val{:J2},
-                         "J4"       => Val{:J4},
-                         "Two Body" => Val{:twobody})
+const propagators = Dict("J2"       => Val(:J2),
+                         "J4"       => Val(:J4),
+                         "Two Body" => Val(:twobody))
 
 function plot_ground_trace(win_plot,win_error,form)
     # Make sure we updated the current input.
@@ -321,14 +321,14 @@ function menus_and_forms()
     form = create_form(fields)
 
     # Set field types.
-    set_field_type(form, "a",    Val{:numeric}, 2, 6400, typemax(Int))
-    set_field_type(form, "e",    Val{:numeric}, 6,    0, 1-eps())
-    set_field_type(form, "i",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "Ω",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "ω",    Val{:numeric}, 3, -180, +180)
-    set_field_type(form, "f",    Val{:numeric}, 3, -180, +180)
+    set_field_type(form, "a",    Val(:numeric), 2, 6400, typemax(Int))
+    set_field_type(form, "e",    Val(:numeric), 6,    0, 1-eps())
+    set_field_type(form, "i",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "Ω",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "ω",    Val(:numeric), 3, -180, +180)
+    set_field_type(form, "f",    Val(:numeric), 3, -180, +180)
     enums = ["J2", "J4", "Two Body"]
-    set_field_type(form, "prop", Val{:enum}, enums)
+    set_field_type(form, "prop", Val(:enum), enums)
 
     # Post form.
     set_form_win(form, win_gt_inputs)
@@ -350,7 +350,7 @@ function menus_and_forms()
     form = create_form(fields)
 
     # Set field types.
-    set_field_type(form, "lt", Val{:numeric}, 2, 0, 24)
+    set_field_type(form, "lt", Val(:numeric), 2, 0, 24)
 
     # Post form.
     set_form_win(form, win_raan_input)

--- a/examples/old/satellite_simulator.jl
+++ b/examples/old/satellite_simulator.jl
@@ -65,7 +65,7 @@ function satellite_simulator()
     2 22490  24.9683 170.6788 0043029 357.3326 117.9323 14.44539175364603
     """[1];
 
-    orbp = init_orbit_propagator(Val{:sgp4}, tle_scd1);
+    orbp = init_orbit_propagator(Val(:sgp4), tle_scd1);
 
     # Vectors to store the latitude and longitude.
     lat = Float64[]

--- a/examples/plots.jl
+++ b/examples/plots.jl
@@ -25,20 +25,20 @@ function plots()
                         anchor_top = (rootwin, :top, 0),
                         anchor_right = (rootwin, :right, 0),
                         anchor_bottom = (rootwin, :bottom, 0))
-    con = create_widget(Val{:container}, win)
+    con = create_widget(Val(:container), win)
 
-    func = create_widget(Val{:form}, con, ["Function y ="], borders = true,
+    func = create_widget(Val(:form), con, ["Function y ="], borders = true,
                          anchor_left = (win, :left, 1),
                          anchor_top  = (win, :top,  0))
 
-    label = create_widget(Val{:label}, con,
+    label = create_widget(Val(:label), con,
                           anchor_left  = (func, :left,   0),
                           anchor_right = (func, :right,  0),
                           anchor_top   = (func, :bottom, 0),
                           alignment    = :c,
                           text = "Use `t` as the time variable for the plots.")
 
-    label = create_widget(Val{:label}, con,
+    label = create_widget(Val(:label), con,
                           anchor_left  = (func,  :left,   0),
                           anchor_right = (func,  :right,  0),
                           anchor_top   = (label, :bottom, 2),
@@ -47,7 +47,7 @@ function plots()
                           fill_color   = true,
                           text = "Setup limits")
 
-    tlim = create_widget(Val{:form}, con, ["t min.", "t max."],
+    tlim = create_widget(Val(:form), con, ["t min.", "t max."],
                          anchor_left   = (func,  :left,    0),
                          anchor_top    = (label, :bottom,  0),
                          anchor_right  = (func,  :center, -1),
@@ -55,7 +55,7 @@ function plots()
                          color_invalid = c3,
                          validator     = Float64)
 
-    ylim = create_widget(Val{:form}, con, ["y min.", "y max."],
+    ylim = create_widget(Val(:form), con, ["y min.", "y max."],
                          anchor_left   = (func,  :center, +1),
                          anchor_top    = (label, :bottom,  0),
                          anchor_right  = (func,  :right,   0),
@@ -63,7 +63,7 @@ function plots()
                          color_invalid = c3,
                          validator     = Float64)
 
-    label = create_widget(Val{:label}, con,
+    label = create_widget(Val(:label), con,
                           anchor_left  = (func, :left,   0),
                           anchor_right = (func, :right,  0),
                           anchor_top   = (ylim, :bottom, 2),
@@ -91,7 +91,7 @@ function plots()
     rb = nothing
 
     for i = 1:length(color_keys)
-        rb = create_widget(Val{:radio_button}, con,
+        rb = create_widget(Val(:radio_button), con,
                            group_name      = "Color",
                            label           = color_keys[i],
                            anchor_left     = (lanchor_w, lanchor_a, 0),
@@ -113,7 +113,7 @@ function plots()
         end
     end
 
-    bplot = create_widget(Val{:button}, con,
+    bplot = create_widget(Val(:button), con,
                           label           = "Plot",
                           anchor_left     = (func, :left,   0),
                           anchor_top      = (rb  , :bottom, 3),
@@ -121,7 +121,7 @@ function plots()
                           width           = 14,
                           color_highlight = c2)
 
-    bcplt = create_widget(Val{:button}, con,
+    bcplt = create_widget(Val(:button), con,
                           label             = "Clear plot",
                           anchor_center     = (func, :center, 0),
                           anchor_top        = (rb  , :bottom, 3),
@@ -129,7 +129,7 @@ function plots()
                           width             = 14,
                           color_highlight   = c2)
 
-    bcfor = create_widget(Val{:button}, con,
+    bcfor = create_widget(Val(:button), con,
                           label           = "Clear form",
                           anchor_right    = (func, :right,  0),
                           anchor_top      = (rb  , :bottom, 3),
@@ -137,7 +137,7 @@ function plots()
                           width           = 14,
                           color_highlight = c2)
 
-    tplot  = create_widget(Val{:label}, con,
+    tplot  = create_widget(Val(:label), con,
                            anchor_left    = (con, :center, 0),
                            anchor_right   = (con, :right,  0),
                            anchor_top     = (con, :top,    1),
@@ -147,7 +147,7 @@ function plots()
                            alignment      = :c)
 
     str    = create_plot([0], [0], :red, get_limits(tlim,ylim)...)
-    canvas = create_widget(Val{:ansi_label}, con, text = str,
+    canvas = create_widget(Val(:ansi_label), con, text = str,
                            anchor_left    = (tplot, :left,   0),
                            anchor_right   = (tplot, :right,  0),
                            anchor_top     = (tplot, :bottom, 1),

--- a/examples/tictactoe.jl
+++ b/examples/tictactoe.jl
@@ -44,7 +44,7 @@ function accept_focus(widget::WidgetField)
 end
 
 # Function to create the widget.
-function create_widget(::Type{Val{:field}}, parent::WidgetParent, top::Integer,
+function create_widget(::Val{:field}, parent::WidgetParent, top::Integer,
                        left::Integer, pos::Tuple{Int,Int} = (0,0))
 
     height = 3
@@ -227,22 +227,22 @@ function tictactoe()
                                             title = " Tic Tac Toe ",
                                             height = 18, width = 60,
                                             top = 2, left = 2)
-    board    = create_widget(Val{:label}, con;
+    board    = create_widget(Val(:label), con;
                              top = 2, left = 2, height = 11, width = 24,
                              text = board, color = pb)
-    ~        = create_widget(Val{:label}, con;
+    ~        = create_widget(Val(:label), con;
                              top = 2, left = 30, height = 1, width = 18,
                              text = "Player 1: $(ticks[1])", color = p1)
-    ~        = create_widget(Val{:label}, con;
+    ~        = create_widget(Val(:label), con;
                              top = 3, left = 30, height = 1, width = 18,
                              text = "Player 2: $(ticks[2])", color = p2)
-    result   = create_widget(Val{:label}, con;
+    result   = create_widget(Val(:label), con;
                              top = 5, left = 30, height = 2, width = 27,
                              text = "", color = p0)
-    info     = create_widget(Val{:label}, con;
+    info     = create_widget(Val(:label), con;
                              top = 15, left = 2, height = 1, width = 20,
                              text = "Press F1 to exit.", color = p0)
-    fields   = [create_widget(Val{:field}, con, 2 + 4(i-1), 2 + 8(j-1), (i,j)) for i = 1:3,j = 1:3]
+    fields   = [create_widget(Val(:field), con, 2 + 4(i-1), 2 + 8(j-1), (i,j)) for i = 1:3,j = 1:3]
 
     # Initialize the focus manager.
     tui.focus_chain = [win]

--- a/examples/windows_and_widgets.jl
+++ b/examples/windows_and_widgets.jl
@@ -25,23 +25,23 @@ function windows_and_widgets()
         w,c  = create_window_with_container(border = true, title = title,
                                             top = x, left = y, height = 10,
                                             width = 56)
-        l    = create_widget(Val{:label}, c;
+        l    = create_widget(Val(:label), c;
                              top = 2, left = 2, height = 1,
                              text = "The last pressed button was:", color = p0)
-        text = create_widget(Val{:label}, c;
+        text = create_widget(Val(:label), c;
                              anchor_middle = (l, :middle, 0),
                              anchor_left   = (l, :right,  1),
                              width = 10, text = "", color = p2)
-        bt1  = create_widget(Val{:button}, c;
+        bt1  = create_widget(Val(:button), c;
                              top = 5, anchor_left = (c, :left, 0),
                              label = "Button 1", color = p1,
                              color_highlight = p3, style = :simple)
-        bt2  = create_widget(Val{:button}, c,
+        bt2  = create_widget(Val(:button), c,
                              anchor_middle = (bt1, :middle, 0),
                              anchor_center = (c, :center, 0),
                              label = "Button 2", color = p1,
                              color_highlight = p3, style = :boxed)
-        bt3  = create_widget(Val{:button}, c;
+        bt3  = create_widget(Val(:button), c;
                              anchor_middle = (bt2, :middle, 0),
                              anchor_right = (c, :right, 0),
                              label = "Button 3", color = p1,

--- a/src/widgets/ansi_labels.jl
+++ b/src/widgets/ansi_labels.jl
@@ -31,7 +31,7 @@ end
 # Labels cannot accept focus.
 accept_focus(widget::WidgetANSILabel) = false
 
-function create_widget(::Type{Val{:ansi_label}}, parent::WidgetParent;
+function create_widget(::Val{:ansi_label}, parent::WidgetParent;
                        alignment = :l,
                        color::Int = 0,
                        text::AbstractString = "Text",

--- a/src/widgets/button.jl
+++ b/src/widgets/button.jl
@@ -45,7 +45,7 @@ function accept_focus(widget::WidgetButton)
     return true
 end
 
-function create_widget(::Type{Val{:button}}, parent::WidgetParent;
+function create_widget(::Val{:button}, parent::WidgetParent;
                        label::AbstractString = "Button",
                        color::Int = 0,
                        color_highlight::Int = 0,

--- a/src/widgets/composed/form.jl
+++ b/src/widgets/composed/form.jl
@@ -28,7 +28,7 @@ end
 #                                     API
 ################################################################################
 
-function create_widget(::Type{Val{:form}}, parent::WidgetParent,
+function create_widget(::Val{:form}, parent::WidgetParent,
                        labels::Vector{String}; borders::Bool = false,
                        color_valid::Int = 0,
                        color_invalid::Int = 0,
@@ -64,7 +64,7 @@ function create_widget(::Type{Val{:form}}, parent::WidgetParent,
     end
 
     # Create the container.
-    container = create_widget(Val{:container}, parent; opc = opc,
+    container = create_widget(Val(:container), parent; opc = opc,
                               composed = true)
 
     widget_labels = Vector{WidgetLabel}(undef, nfields)
@@ -74,7 +74,7 @@ function create_widget(::Type{Val{:form}}, parent::WidgetParent,
         at  = i == 1 ? container : widget_inputs[i-1]
         ats = i == 1 ? :top : :bottom
 
-        wii = create_widget(Val{:input_field}, container,
+        wii = create_widget(Val(:input_field), container,
                             anchor_top    = (at, ats, 0),
                             anchor_left   = (container, :left, lmax+1),
                             anchor_right  = (container, :right, 0),
@@ -83,7 +83,7 @@ function create_widget(::Type{Val{:form}}, parent::WidgetParent,
                             border        = borders,
                             validator     = validator[i])
 
-        wli = create_widget(Val{:label}, container,
+        wli = create_widget(Val(:label), container,
                             anchor_middle = (wii, :middle, 0),
                             anchor_left   = (container, :left, 0),
                             width         = lmax,

--- a/src/widgets/container/container.jl
+++ b/src/widgets/container/container.jl
@@ -33,7 +33,7 @@ end
 #                                     API
 ################################################################################
 
-function create_widget(::Type{Val{:container}}, parent::T;
+function create_widget(::Val{:container}, parent::T;
                        opc = nothing, border::Bool = false,
                        border_color::Int = -1, composed::Bool = false,
                        title::AbstractString = "", title_alignment::Symbol = :l,

--- a/src/widgets/input_field.jl
+++ b/src/widgets/input_field.jl
@@ -74,7 +74,7 @@ function accept_focus(widget::WidgetInputField)
     return true
 end
 
-function create_widget(::Type{Val{:input_field}}, parent::WidgetParent;
+function create_widget(::Val{:input_field}, parent::WidgetParent;
                        border::Bool = false,
                        color_valid::Int = 0,
                        color_invalid::Int = 0,

--- a/src/widgets/labels.jl
+++ b/src/widgets/labels.jl
@@ -32,7 +32,7 @@ end
 # Labels cannot accept focus.
 accept_focus(widget::WidgetLabel) = false
 
-function create_widget(::Type{Val{:label}}, parent::WidgetParent;
+function create_widget(::Val{:label}, parent::WidgetParent;
                        alignment = :l,
                        color::Int = 0,
                        fill_color::Bool = false,

--- a/src/widgets/progress_bar.jl
+++ b/src/widgets/progress_bar.jl
@@ -33,7 +33,7 @@ end
 # Progress bar cannot accept focus.
 accept_focus(widget::WidgetProgressBar) = false
 
-function create_widget(::Type{Val{:progress_bar}}, parent::WidgetParent;
+function create_widget(::Val{:progress_bar}, parent::WidgetParent;
                        border::Bool = false,
                        color::Int = 0,
                        color_highlight::Int = 0,

--- a/src/widgets/radio_button.jl
+++ b/src/widgets/radio_button.jl
@@ -36,7 +36,7 @@ _radio_buttons_groups = Dict{String,Vector{WidgetRadioButton}}()
 
 accept_focus(widget::WidgetRadioButton) = accept_focus(widget.button)
 
-function create_widget(::Type{Val{:radio_button}}, parent::WidgetParent;
+function create_widget(::Val{:radio_button}, parent::WidgetParent;
                        label::AbstractString = "Button",
                        color::Int = 0,
                        color_highlight::Int = 0,
@@ -46,7 +46,7 @@ function create_widget(::Type{Val{:radio_button}}, parent::WidgetParent;
                        kwargs...)
 
     # Create the button widget.
-    button = create_widget(Val{:button}, parent;
+    button = create_widget(Val(:button), parent;
                            label = glyph_deselected * " " * label,
                            color = color, color_highlight = color_highlight,
                            style = :none, _derive = true, kwargs...)

--- a/src/windows/create_destroy.jl
+++ b/src/windows/create_destroy.jl
@@ -155,7 +155,7 @@ size of the window buffer.
 """
 function create_window_with_container(vargs...; kwargs...)
     win = create_window(vargs...; kwargs...)
-    con = create_widget(Val{:container}, win)
+    con = create_widget(Val(:container), win)
     return win, con
 end
 

--- a/test/log_test/model.jl
+++ b/test/log_test/model.jl
@@ -14,15 +14,15 @@ function log_test()
 
     w,c = create_window_with_container(border = true, title = " WINDOW ",
                                        top = 2, left = 2, width = 56, height = 10)
-    ~   = create_widget(Val{:label}, c;
+    ~   = create_widget(Val(:label), c;
                         anchor_top = (c, :top, 0),   height = 1,
                         anchor_left = (c, :left, 0), width  = 40,
                         text = "This is a label", color = p0)
-    bt  = create_widget(Val{:button}, c;
+    bt  = create_widget(Val(:button), c;
                         anchor_middle = (c, :middle, 0),
                         anchor_left = (c, :left, 0), width = 12,
                         label = "Button 1", color = p0, color_highlight = p1)
-    pb  = create_widget(Val{:progress_bar}, c;
+    pb  = create_widget(Val(:progress_bar), c;
                          anchor_bottom = (c, :bottom, 0), width = 40,
                          anchor_left = (c, :left, 0), value = 100)
 


### PR DESCRIPTION
Generally when dispatching on `Val`, you create one with `Val(:thing)` (note the parens and lack of curlies). Then you can dispatch on `::Val{:thing}` instead of `::Type{Val{:thing}}`. 

I think this is all correct, I wasn't totally sure about how `set_field_type` worked though. 