### PR TITLE
Update docstring format, use @eval a bit less 

### DIFF
--- a/src/colors.jl
+++ b/src/colors.jl
@@ -10,7 +10,7 @@ export ncurses_color, get_color_pair, modify_color, init_color_pair, set_color,
        unset_color
 
 """
-    function ncurses_color([foreground, background,] attrs::Int = 0; kwargs...)
+    ncurses_color([foreground, background,] attrs::Int = 0; kwargs...)
 
 Return a mask to apply a color format with the foreground color `foreground`,
 background color `background`, and the attributes `attrs`.
@@ -72,7 +72,7 @@ function ncurses_color(attrs::Int = 0;
 end
 
 """
-    function get_color_pair(foreground::Int, background::Int)
+    get_color_pair(foreground::Int, background::Int)
 
 Return the ID of the color pair (`foreground`, `background`), or `nothing` if
 the color pair is not initialized.
@@ -82,7 +82,7 @@ get_color_pair(foreground::Int, background::Int) =
     findfirst(x->x == (foreground, background), tui.initialized_color_pairs)
 
 """
-    function init_color_pair(foreground::Symbol, background::Symbol)
+    init_color_pair(foreground::Symbol, background::Symbol)
 
 Initialize the color pair (`foreground`, `background`) and return its ID. If the
 pair already exists, then just the function just returns its ID.
@@ -121,7 +121,7 @@ function init_color_pair(foreground::Int, background::Int)
 end
 
 """
-    function modify_color([name::Symbol, ]id::Int, r::Int, g::Int, b::Int)
+    modify_color([name::Symbol, ]id::Int, r::Int, g::Int, b::Int)
 
 Modify the color ID `id` to the RGB value (`r`,`g`,`b`). If the symbol `name` is
 available, then the user can select this color ID by using `name` instead of the
@@ -156,7 +156,7 @@ function modify_color(id::Int, r::Int, g::Int, b::Int)
 end
 
 """
-    function set_color([win::Window,] color::Int)
+    set_color([win::Window,] color::Int)
 
 Set the color of the window `win` to `color` (see `ncurses_color`). If `win` is
 omitted, then it defaults to the root window.
@@ -170,7 +170,7 @@ function set_color(win::Window, color::Int)
 end
 
 """
-    function unset_color([win::Window,] color::Number)
+    unset_color([win::Window,] color::Number)
 
 Unset the color `color` (see `ncurses_color`) in the window `win`. If `win` is
 omitted, then it defaults to the root window.
@@ -188,7 +188,7 @@ end
 ################################################################################
 
 """
-    function _get_color_index(color::Symbol)
+    _get_color_index(color::Symbol)
 
 Return the index related to the color `color`.
 

--- a/src/focus_manager.jl
+++ b/src/focus_manager.jl
@@ -10,7 +10,7 @@ export get_focused_window, init_focus_manager, process_focus,
        set_previous_window_func
 
 """
-    function get_focused_window()
+    get_focused_window()
 
 Return the focused window.
 
@@ -18,7 +18,7 @@ Return the focused window.
 get_focused_window() = tui.focus_chain[tui.focus_id]
 
 """
-    function init_focus_manager()
+    init_focus_manager()
 
 Initialization of the focus manager. The elements in `focus_chain` are iterated
 to find the first one that can accept the focus.
@@ -29,7 +29,7 @@ function init_focus_manager()
 end
 
 """
-    function process_focus(k::Keystroke)
+    process_focus(k::Keystroke)
 
 Process the focus considering the user's keystorke `k`.
 
@@ -76,7 +76,7 @@ function process_focus(k::Keystroke)
 end
 
 """
-    function next_window()
+    next_window()
 
 Move the focus to the next window.
 
@@ -129,7 +129,7 @@ function next_window()
 end
 
 """
-    function previous_window()
+    previous_window()
 
 Move the focus to the previous window.
 
@@ -182,7 +182,7 @@ function previous_window()
 end
 
 """
-    function set_focus_chain(wins::Window...; new_focus_id::Int = 1)
+    set_focus_chain(wins::Window...; new_focus_id::Int = 1)
 
 Set the focus chain, *i.e.* the ordered list of windows that can receive the
 focus. The keyword `new_focus_id` can be set to specify which element is
@@ -198,7 +198,7 @@ function set_focus_chain(wins::Window...; new_focus_id::Int = 1)
 end
 
 """
-    function set_next_window_func(f)
+    set_next_window_func(f)
 
 Set the function `f` to be the one that will be called to check whether the user
 wants the next window. The signature must be:
@@ -214,7 +214,7 @@ function set_next_window_func(f)
 end
 
 """
-    function set_previous_window_func(f)
+    set_previous_window_func(f)
 
 Set the function `f` to be the one that will be called to check whether the user
 wants the previous window. The signature must be:

--- a/src/init_destruct.jl
+++ b/src/init_destruct.jl
@@ -8,7 +8,7 @@
 export init_tui, destroy_tui
 
 """
-    function init_tui(dir::String = "")
+    init_tui(dir::String = "")
 
 Initialize the Text User Interface (TUI). The full-path of the ncurses directory
 can be specified by `dir`. If it is empty or omitted, then it will look on the
@@ -38,7 +38,7 @@ function init_tui(dir::String = "")
 end
 
 """
-    function destroy_tui()
+    destroy_tui()
 
 Destroy the Text User Interface (TUI).
 

--- a/src/input.jl
+++ b/src/input.jl
@@ -20,7 +20,7 @@ include("keycodes.jl")
 ################################################################################
 
 """
-    function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
+    jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
 
 Wait for an keystroke in the window `win` and return it (see `Keystroke`).  If
 `win` is `nothing`, then `getch()` will be used instead of `wgetch(win)` to

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -48,7 +48,7 @@ macro reset_log_ident() return :( logger.pad = 0 )   end
 ################################################################################
 
 """
-    function log_message(level::Int, msg::AbstractString, id::AbstractString = "")
+    log_message(level::Int, msg::AbstractString, id::AbstractString = "")
 
 Log the message `msg` with level `level`. The ID of the called can be specified
 by `id`.

--- a/src/menus.jl
+++ b/src/menus.jl
@@ -112,7 +112,7 @@ function create_menu(names::Vector{T1},
 end
 
 """
-    function destroy_menu(menu::TUI_MENU)
+    destroy_menu(menu::TUI_MENU)
 
 Destroy the menu `menu`.
 
@@ -127,7 +127,7 @@ function destroy_menu(menu::TUI_MENU)
 end
 
 """
-    function post_menu(menu::TUI_MENU)
+    post_menu(menu::TUI_MENU)
 
 Post the menu `menu`.
 
@@ -138,7 +138,7 @@ function post_menu(menu::TUI_MENU)
 end
 
 """
-    function unpost_menu(menu::TUI_MENU)
+    unpost_menu(menu::TUI_MENU)
 
 Unpost the menu `menu`.
 
@@ -149,7 +149,7 @@ function unpost_menu(menu::TUI_MENU)
 end
 
 """
-    function set_menu_win(menu::TUI_MENU, win::Window)
+    set_menu_win(menu::TUI_MENU, win::Window)
 
 Set menu `menu` window to `win`.
 
@@ -182,7 +182,7 @@ Return the current item of the menu `menu`.
 current_item(menu::TUI_MENU) = current_item(menu.ptr)
 
 """
-    function current_item_name(menu::TUI_MENU)
+    current_item_name(menu::TUI_MENU)
 
 Return the item name of the menu `menu`.
 
@@ -195,7 +195,7 @@ function current_item_name(menu::TUI_MENU)
 end
 
 """
-    function current_item_desc(menu::TUI_MENU)
+    current_item_desc(menu::TUI_MENU)
 
 Return the item description of the menu `menu`.
 
@@ -208,7 +208,7 @@ function current_item_desc(menu::TUI_MENU)
 end
 
 """
-    function selected_items(menu::TUI_MENU)
+    selected_items(menu::TUI_MENU)
 
 Return a `Vector` with the selected items in the menu `menu`.
 
@@ -224,7 +224,7 @@ function selected_items(menu::TUI_MENU)
 end
 
 """
-    function selected_items_names(menu::TUI_MENU)
+    selected_items_names(menu::TUI_MENU)
 
 Return a `Vector` with the selected items names in the menu `menu`.
 
@@ -240,7 +240,7 @@ function selected_items_names(menu::TUI_MENU)
 end
 
 """
-    function selected_items_desc(menu::TUI_MENU)
+    selected_items_desc(menu::TUI_MENU)
 
 Return a `Vector` with the selected items descriptions in the menu `menu`.
 
@@ -259,7 +259,7 @@ end
 # ==============================================================================
 
 """
-    function menu_down_item(menu::TUI_MENU)
+    menu_down_item(menu::TUI_MENU)
 
 Move down to an item of the menu `menu`.
 
@@ -270,7 +270,7 @@ function menu_down_item(menu::TUI_MENU)
 end
 
 """
-    function menu_left_item(menu::TUI_MENU)
+    menu_left_item(menu::TUI_MENU)
 
 Move left to an item of the menu `menu`.
 
@@ -281,7 +281,7 @@ function menu_left_item(menu::TUI_MENU)
 end
 
 """
-    function menu_right_item(menu::TUI_MENU)
+    menu_right_item(menu::TUI_MENU)
 
 Move right to an item of the menu `menu`.
 
@@ -292,7 +292,7 @@ function menu_right_item(menu::TUI_MENU)
 end
 
 """
-    function menu_up_item(menu::TUI_MENU)
+    menu_up_item(menu::TUI_MENU)
 
 Move up to an item of the menu `menu`.
 
@@ -303,7 +303,7 @@ function menu_up_item(menu::TUI_MENU)
 end
 
 """
-    function menu_down_line(menu::TUI_MENU)
+    menu_down_line(menu::TUI_MENU)
 
 Scroll down a line of the menu `menu`.
 
@@ -314,7 +314,7 @@ function menu_down_line(menu::TUI_MENU)
 end
 
 """
-    function menu_up_line(menu::TUI_MENU)
+    menu_up_line(menu::TUI_MENU)
 
 Scroll up a line of the menu `menu`.
 
@@ -325,7 +325,7 @@ function menu_up_line(menu::TUI_MENU)
 end
 
 """
-    function menu_down_page(menu::TUI_MENU)
+    menu_down_page(menu::TUI_MENU)
 
 Scroll down a page of the menu `menu`.
 
@@ -336,7 +336,7 @@ function menu_down_page(menu::TUI_MENU)
 end
 
 """
-    function menu_up_page(menu::TUI_MENU)
+    menu_up_page(menu::TUI_MENU)
 
 Scroll up a page of the menu `menu`.
 
@@ -347,7 +347,7 @@ function menu_up_page(menu::TUI_MENU)
 end
 
 """
-    function menu_first_item(menu::TUI_MENU)
+    menu_first_item(menu::TUI_MENU)
 
 Move to the first item of the menu `menu`.
 
@@ -358,7 +358,7 @@ function menu_first_item(menu::TUI_MENU)
 end
 
 """
-    function menu_last_item(menu::TUI_MENU)
+    menu_last_item(menu::TUI_MENU)
 
 Move to the last item of the menu `menu`.
 
@@ -369,7 +369,7 @@ function menu_last_item(menu::TUI_MENU)
 end
 
 """
-    function menu_next_item(menu::TUI_MENU)
+    menu_next_item(menu::TUI_MENU)
 
 Move to the next item of the menu `menu`.
 
@@ -380,7 +380,7 @@ function menu_next_item(menu::TUI_MENU)
 end
 
 """
-    function menu_prev_item(menu::TUI_MENU)
+    menu_prev_item(menu::TUI_MENU)
 
 Move to the previous menu item of the `menu`.
 
@@ -391,7 +391,7 @@ function menu_prev_item(menu::TUI_MENU)
 end
 
 """
-    function menu_toggle_item(menu::TUI_MENU)
+    menu_toggle_item(menu::TUI_MENU)
 
 Toggle the current item of the menu `menu`.
 
@@ -455,7 +455,7 @@ end
 # ==============================================================================
 
 """
-    function accept_focus(menu::TUI_MENU)
+    accept_focus(menu::TUI_MENU)
 
 Command executed when menu `menu` must state whether or not it accepts the
 focus. If the focus is accepted, then this function returns `true`. Otherwise,
@@ -470,7 +470,7 @@ function accept_focus(menu::TUI_MENU)
 end
 
 """
-    function process_focus(menu::TUI_MENU, k::Keystroke)
+    process_focus(menu::TUI_MENU, k::Keystroke)
 
 Process the actions when the menu `menu` is in focus and the keystroke `k` was
 issued by the user.
@@ -481,7 +481,7 @@ function process_focus(menu::TUI_MENU, k::Keystroke)
 end
 
 """
-    function release_focus(menu::TUI_MENU)
+    release_focus(menu::TUI_MENU)
 
 Release the focus from the menu `menu`.
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -10,7 +10,7 @@ export obj_desc, obj_to_ptr
 const _test_hide_address = [false]
 
 """
-    function obj_desc(obj)
+    obj_desc(obj)
 
 Return a string with the description of the object `obj` formed by:
 

--- a/src/objects/anchors.jl
+++ b/src/objects/anchors.jl
@@ -13,7 +13,7 @@ export object_positioning_conf, compute_object_positioning
 ################################################################################
 
 """
-    function compute_object_positioning(opc::ObjectPositioningConfiguration, parent)
+    compute_object_positioning(opc::ObjectPositioningConfiguration, parent)
 
 Compute the object position based on the configuration `opc` and on its
 parent object `parent`.
@@ -166,7 +166,7 @@ function compute_object_positioning(opc::ObjectPositioningConfiguration, parent)
 end
 
 """
-    function object_positioning_conf(...)
+    object_positioning_conf(...)
 
 Helper function to create the object positioning configuration. In this case,
 the anchor can be passed by keywords and a tuple containing the object and its
@@ -216,7 +216,7 @@ end
 
 """
     _check_vertical_anchor(anchor::Nothing)
-    function _check_vertical_anchor(anchor::Anchor)
+    _check_vertical_anchor(anchor::Anchor)
 
 Check if the `side` parameter of `anchor` is valid for vertical positioning. If
 `anchor` is `nothing`, then `true` is always returned.
@@ -226,7 +226,7 @@ _check_vertical_anchor(anchor::Nothing) = true
 _check_vertical_anchor(anchor::Anchor)  = anchor.side ∈ [:bottom,:middle,:top]
 
 """
-    function _check_horizontal_anchor(anchor::Anchor)
+    _check_horizontal_anchor(anchor::Anchor)
 
 Check if the `side` parameter of `anchor` is valid for horizontal positioning.
 If `anchor` is `nothing`, then `true` is always returned.
@@ -236,7 +236,7 @@ _check_horizontal_anchor(anchor::Nothing) = true
 _check_horizontal_anchor(anchor::Anchor)  = anchor.side ∈ [:left,:center,:right]
 
 """
-    function _get_anchor(anchor::Anchor, parent)
+    _get_anchor(anchor::Anchor, parent)
 
 Return the line or column related to the anchor `anchor`. If the object in
 `anchor` is the `parent`, then the positioning will be computed relative to the
@@ -279,7 +279,7 @@ function _get_anchor(anchor::Anchor, parent)
 end
 
 """
-    function _process_vertical_info!(opc::ObjectPositioningConfiguration)
+    _process_vertical_info!(opc::ObjectPositioningConfiguration)
 
 Process the vertical positioning information in `opc` and write the variable
 `vertical` of the same structure. The possible vertical positioning information
@@ -333,7 +333,7 @@ function _process_vertical_info!(opc::ObjectPositioningConfiguration)
 end
 
 """
-    function _process_horizontal_info!(opc::ObjectPositioningConfiguration)
+    _process_horizontal_info!(opc::ObjectPositioningConfiguration)
 
 Process the horizontal positioning information in `opc` and write the variable
 `horizontal` of the same structure. The possible horizontal positioning information
@@ -387,7 +387,7 @@ function _process_horizontal_info!(opc::ObjectPositioningConfiguration)
 end
 
 """
-    function _str(wpc::ObjectPositioningConfiguration)
+    _str(wpc::ObjectPositioningConfiguration)
 
 Convert the information in `wpc` to a string for debugging purposes.
 

--- a/src/objects/api.jl
+++ b/src/objects/api.jl
@@ -10,7 +10,7 @@ export get_left, get_height, get_width, get_top, get_visible_height,
        get_visible_width, reposition!
 
 """
-    function get_bottom(object)
+    get_bottom(object)
 
 Return the left of the object w.r.t. its parent.
 
@@ -26,7 +26,7 @@ Return the left of the object for a child object.
 get_left_for_child
 
 """
-    function get_height(object)
+    get_height(object)
 
 Return the usable height of object `object`.
 
@@ -42,7 +42,7 @@ Return the usable height of the object for a child object.
 get_height_for_child
 
 """
-    function get_width(object)
+    get_width(object)
 
 Return the usable width of object `object`.
 
@@ -58,7 +58,7 @@ Return the usable width of object `object` for a child object.
 get_width_for_child
 
 """
-    function get_top(object)
+    get_top(object)
 
 Return the top of the object w.r.t. its parent.
 
@@ -74,7 +74,7 @@ Return the top of the object for a child object.
 get_top_for_child
 
 """
-    function reposition!(object)
+    reposition!(object)
 
 Reposition the object baesd on the stored configuration.
 

--- a/src/submodules/NCurses/NCurses.jl
+++ b/src/submodules/NCurses/NCurses.jl
@@ -26,7 +26,7 @@ include("./panel/panel_functions.jl")
 export load_ncurses, init_ncurses
 
 """
-    function load_ncurses([dir::String])
+    load_ncurses([dir::String])
 
 Load ncurses libraries at directory `dir`. If it is omitted or if it is empty,
 then the bundled Ncurses version in the package `Ncurses_jll` will be used.

--- a/src/submodules/NCurses/form/form_functions.jl
+++ b/src/submodules/NCurses/form/form_functions.jl
@@ -101,8 +101,8 @@ for (f,r,v,j,c) in
         For more information, consult `libform` documentation.
         """
         $f($(argsj...)) where T<:Integer = @_ccallf $f($(argsc...))::$r
+        export $f
     end
-    @eval export $f
 end
 
 # Functions that depends on arguments that must be `Integer`
@@ -145,8 +145,8 @@ for (f,r,v,j,c) in
         For more information, consult `libform` documentation.
         """
         $f($(argsj...)) where T<:Integer = @_ccallf $f($(argsc...))::$r
+        export $f
     end
-    @eval export $f
 end
 
 # Functions that arguments must be `AbstractString` and `Integer`
@@ -172,7 +172,7 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
+        """
             $($fb)($($args_str)) where {Ti<:Integer,Ts<:AbstractString}
 
         **Return type**: `$($r)`
@@ -180,8 +180,8 @@ for (f,r,v,j,c) in
         For more information, consult `libform` documentation.
         """
         $f($(argsj...)) where {Ti<:Integer,Ts<:AbstractString} = @_ccallf $f($(argsc...))::$r
+        export $f
     end
-    @eval export $f
 end
 
 # Global symbols
@@ -193,6 +193,12 @@ for s in (:TYPE_ALNUM, :TYPE_ALPHA, :TYPE_ENUM, :TYPE_INTEGER, :TYPE_NUMERIC,
     sq = Meta.quot(s)
 
     @eval begin
+        """
+            $($sq)()
+
+        Return a pointer to the global symbol `$($sq)` of `libform`.
+
+        """
         function $s()
             ptr = getfield(ncurses, $sq)
             if ptr == C_NULL
@@ -204,14 +210,5 @@ for s in (:TYPE_ALNUM, :TYPE_ALPHA, :TYPE_ENUM, :TYPE_INTEGER, :TYPE_NUMERIC,
             return ptr
         end
         export $s
-    end
-
-    @eval begin
-        @doc """
-            function $($sq)()
-
-        Return a pointer to the global symbol `$($sq)` of `libform`.
-
-        """ $s
     end
 end

--- a/src/submodules/NCurses/form/form_functions.jl
+++ b/src/submodules/NCurses/form/form_functions.jl
@@ -12,7 +12,7 @@
 ################################################################################
 
 """
-    macro _ccallf(expr)
+    @_ccallf expr
 
 Make a `ccall` to a `libform` function. The usage should be:
 
@@ -94,7 +94,7 @@ for (f,r,v,j,c) in
 
     @eval begin
         """
-            function $($fb)($($args_str))
+            $($fb)($($args_str))
 
         **Return type**: `$($r)`
 
@@ -138,7 +138,7 @@ for (f,r,v,j,c) in
 
     @eval begin
         """
-            function $($fb)($($args_str)) where T<:Integer
+            $($fb)($($args_str)) where T<:Integer
 
         **Return type**: `$($r)`
 
@@ -173,7 +173,7 @@ for (f,r,v,j,c) in
 
     @eval begin
         @doc """
-            function $($fb)($($args_str)) where {Ti<:Integer,Ts<:AbstractString}
+            $($fb)($($args_str)) where {Ti<:Integer,Ts<:AbstractString}
 
         **Return type**: `$($r)`
 

--- a/src/submodules/NCurses/menu/menu_functions.jl
+++ b/src/submodules/NCurses/menu/menu_functions.jl
@@ -80,9 +80,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) = @_ccallm $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -94,13 +91,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
+        """
             function $($fb)($($args_str))
 
         **Return type**: `$($r)`
 
         For more information, consult `libmenu` documentation.
-        """ $f
+        """
+        $f($(argsj...)) = @_ccallm $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -118,9 +117,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:Integer = @_ccallm $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -132,13 +128,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
+        """
             function $($fb)($($args_str)) where T<:Integer
 
         **Return type**: `$($r)`
 
         For more information, consult `libmenu` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:Integer = @_ccallm $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -155,9 +153,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:AbstractString = @_ccallm $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -169,12 +164,14 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
+        """
             function $($fb)($($args_str)) where T<:AbstractString
 
         **Return type**: `$($r)`
 
         For more information, consult `libmenu` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:AbstractString = @_ccallm $f($(argsc...))::$r
+        export $f
     end
 end

--- a/src/submodules/NCurses/menu/menu_functions.jl
+++ b/src/submodules/NCurses/menu/menu_functions.jl
@@ -12,11 +12,11 @@
 ################################################################################
 
 """
-    macro _ccallm(expr)
+    @_ccallm expr
 
 Make a `ccall` to a `libmenu` function. The usage should be:
 
-    @_ccallf function(arg1::Type1, arg2::Type2, ...)::TypeReturn
+    @_ccallm function(arg1::Type1, arg2::Type2, ...)::TypeReturn
 
 It uses the global constant structure `ncurses` to call the function. Hence, it
 must be initialized.

--- a/src/submodules/NCurses/ncurses_functions.jl
+++ b/src/submodules/NCurses/ncurses_functions.jl
@@ -12,7 +12,7 @@
 ################################################################################
 
 """
-    macro _ccalln(expr)
+    @_ccalln expr
 
 Make a `ccall` to a `libncurses` function. The usage should be:
 
@@ -100,9 +100,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -114,13 +111,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str))
+        """
+            $($fb)($($args_str))
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) = @_ccalln $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -156,9 +155,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:Integer = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -170,13 +166,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where T<:Integer
+        """
+            $($fb)($($args_str)) where T<:Integer
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:Integer = @_ccalln $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -194,9 +192,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:jlchtype = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -208,13 +203,17 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where T<:jlchtype
+        """
+            $($fb)($($args_str)) where T<:jlchtype
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:jlchtype = @_ccalln $f($(argsc...))::$r
+        export $f
+
+
     end
 end
 
@@ -237,9 +236,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where {Tc<:jlchtype,Ti<:Integer} = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -251,13 +247,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where {Tc<:jlchtype,Ti<:Integer}
+        """
+            $($fb)($($args_str)) where {Tc<:jlchtype,Ti<:Integer}
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where {Tc<:jlchtype,Ti<:Integer} = @_ccalln $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -274,9 +272,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:AbstractString = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -288,13 +283,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where T<:AbstractString
+        """
+            $($fb)($($args_str)) where T<:AbstractString
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:AbstractString = @_ccalln $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -311,9 +308,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where {Ti<:Integer,Ts<:AbstractString} = @_ccalln $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -325,13 +319,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where {Ti<:Integer,Ts<:AbstractString}
+        """
+            $($fb)($($args_str)) where {Ti<:Integer,Ts<:AbstractString}
 
         **Return type**: `$($r)`
 
         For more information, consult `libncurses` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where {Ti<:Integer,Ts<:AbstractString} = @_ccalln $f($(argsc...))::$r
+        export $f
     end
 end
 

--- a/src/submodules/NCurses/ncurses_functions.jl
+++ b/src/submodules/NCurses/ncurses_functions.jl
@@ -339,7 +339,7 @@ end
 # ==============================================================================
 
 """
-    function ACS_(s::Symbol)
+    ACS_(s::Symbol)
 
 Return the symbol `s` of the `acs_map`. For example, `ACS_HLINE` can be obtained
 from `ACS_(:HLINE)`.
@@ -364,7 +364,7 @@ end
 export ACS_
 
 """
-    function COLS()
+    COLS()
 
 Return the number of columns in the root window. It must be called after
 `initscr()`.
@@ -383,7 +383,7 @@ end
 export COLS
 
 """
-    function LINES()
+    LINES()
 
 Return the number of lines in the root window. It must be called after
 `initscr()`.
@@ -405,7 +405,7 @@ export LINES
 # ==============================================================================
 
 """
-    function wborder(win::Ptr{WINDOW})
+    wborder(win::Ptr{WINDOW})
 
 Call the function `wborder(win, 0, 0, 0, 0, 0, 0, 0, 0)`.
 
@@ -416,7 +416,7 @@ wborder(win::Ptr{WINDOW}) = wborder(win, 0, 0, 0, 0, 0, 0, 0, 0)
 # ==============================================================================
 
 """
-    function curses_version()
+    curses_version()
 
 Return the NCurses version in a named tuple with the following fields:
 

--- a/src/submodules/NCurses/panel/panel_functions.jl
+++ b/src/submodules/NCurses/panel/panel_functions.jl
@@ -76,9 +76,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) = @_ccallp $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -90,13 +87,15 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str))
+        """
+            $($fb)($($args_str))
 
         **Return type**: `$($r)`
 
         For more information, consult `libmenu` documentation.
-        """ $f
+        """
+        $f($(argsj...)) = @_ccallp $f($(argsc...))::$r
+        export $f
     end
 end
 
@@ -112,9 +111,6 @@ for (f,r,v,j,c) in
     argsj = [Meta.parse(i * "::" * j) for (i,j) in zip(v,j)]
     argsc = [Meta.parse(i * "::" * j) for (i,j) in zip(v,c)]
 
-    @eval $f($(argsj...)) where T<:Integer = @_ccallp $f($(argsc...))::$r
-    @eval export $f
-
     # Assemble the argument string to build the function documentation.
     args_str = ""
     for i = 1:length(v)
@@ -126,12 +122,14 @@ for (f,r,v,j,c) in
     end
 
     @eval begin
-        @doc """
-            function $($fb)($($args_str)) where T<:Integer
+        """
+            $($fb)($($args_str)) where T<:Integer
 
         **Return type**: `$($r)`
 
         For more information, consult `libmenu` documentation.
-        """ $f
+        """
+        $f($(argsj...)) where T<:Integer = @_ccallp $f($(argsc...))::$r
+        export $f
     end
 end

--- a/src/submodules/NCurses/panel/panel_functions.jl
+++ b/src/submodules/NCurses/panel/panel_functions.jl
@@ -12,11 +12,11 @@
 ################################################################################
 
 """
-    macro _ccallm(expr)
+    @_ccallm expr
 
 Make a `ccall` to a `libpanel` function. The usage should be:
 
-    @_ccallf function(arg1::Type1, arg2::Type2, ...)::TypeReturn
+    @_ccallm function(arg1::Type1, arg2::Type2, ...)::TypeReturn
 
 It uses the global constant structure `ncurses` to call the function. Hence, it
 must be initialized.

--- a/src/submodules/ParseANSIColors/parse.jl
+++ b/src/submodules/ParseANSIColors/parse.jl
@@ -9,7 +9,7 @@
 export parse_ansi_string
 
 """
-    function parse_ansi_string(str::AbstractString)
+    parse_ansi_string(str::AbstractString)
 
 Parse the string `str` that can contain ANSI color escape sequences. This
 function returns two vectors:

--- a/src/validators.jl
+++ b/src/validators.jl
@@ -9,7 +9,7 @@
 export validate_str
 
 """
-    function validate_str(str::AbstractString, v)
+    validate_str(str::AbstractString, v)
 
 Validate the string `str` using the validator `v`. `v` is an element of the type
 that will be used to validate or a regex.

--- a/src/widgets/ansi_labels.jl
+++ b/src/widgets/ansi_labels.jl
@@ -95,7 +95,7 @@ end
 ################################################################################
 
 """
-    function change_text(widget::WidgetANSILabel, new_text::AbstractString; alignment = :l, color::Int = -1)
+    change_text(widget::WidgetANSILabel, new_text::AbstractString; alignment = :l, color::Int = -1)
 
 Change to text of the label widget `widget` to `new_text`.
 

--- a/src/widgets/button.jl
+++ b/src/widgets/button.jl
@@ -133,7 +133,7 @@ end
 ################################################################################
 
 """
-    function change_label(button::WidgetButton, label::AbstractString)
+    change_label(button::WidgetButton, label::AbstractString)
 
 Change the label of button `button` to `label`.
 

--- a/src/widgets/composed/form.jl
+++ b/src/widgets/composed/form.jl
@@ -118,7 +118,7 @@ end
 ################################################################################
 
 """
-    function clear_data!(widget::WidgetForm)
+    clear_data!(widget::WidgetForm)
 
 Clear the data in all the input fields in the form `widget`.
 
@@ -129,7 +129,7 @@ function clear_data!(widget::WidgetForm)
 end
 
 """
-    function get_data(widget::WidgetInputField)
+    get_data(widget::WidgetInputField)
 
 Return a vector with the data of all fields.
 

--- a/src/widgets/container/api.jl
+++ b/src/widgets/container/api.jl
@@ -10,7 +10,7 @@
 export add_widget, remove_widget
 
 """
-    function add_widget(container::WidgetContainer, widget::Widget)
+    add_widget(container::WidgetContainer, widget::Widget)
 
 Add the widget `widget` to the container `container.
 
@@ -21,7 +21,7 @@ function add_widget(container::WidgetContainer, widget::Widget)
 end
 
 """
-    function remove_widget(container::WidgetContainer, widget::Widget)
+    remove_widget(container::WidgetContainer, widget::Widget)
 
 Remove the widget `widget` from the container `container`.
 
@@ -50,7 +50,7 @@ function remove_widget(container::WidgetContainer, widget::Widget)
 end
 
 """
-    function has_focus(container::WidgetContainer, widget)
+    has_focus(container::WidgetContainer, widget)
 
 Return `true` if the widget `widget` is in focus on container `container`, or
 `false` otherwise.
@@ -64,7 +64,7 @@ function has_focus(container::WidgetContainer, widget)
 end
 
 """
-    function request_focus(container::WidgetContainer, widget)
+    request_focus(container::WidgetContainer, widget)
 
 Request the focus to the widget `widget` of the container `container`. It
 returns `true` if the focus could be changed or `false` otherwise.
@@ -100,7 +100,7 @@ function request_focus(container::WidgetContainer, widget)
 end
 
 """
-    function refresh_window(container::WidgetContainer; force_redraw::Bool = false)
+    refresh_window(container::WidgetContainer; force_redraw::Bool = false)
 
 Ask the parent widget to refresh the window. If `force_redraw` is `true`, then
 all widgets in the window will be updated.
@@ -110,7 +110,7 @@ refresh_window(container::WidgetContainer; force_redraw::Bool = false) =
     refresh_window(container.common.parent; force_redraw = force_redraw)
 
 """
-    function sync_cursor(widget::WidgetContainer)
+    sync_cursor(widget::WidgetContainer)
 
 Synchronize the cursor to the position of the focused widget in container
 `container`. This is necessary because all the operations are done in the

--- a/src/widgets/container/container.jl
+++ b/src/widgets/container/container.jl
@@ -176,7 +176,7 @@ function redraw(container::WidgetContainer)
 end
 
 """
-    function request_next_widget(container::WidgetContainer)
+    request_next_widget(container::WidgetContainer)
 
 Request the next widget in `container`. It returns `true` if a widget has get
 the focus or `false` otherwise.
@@ -185,7 +185,7 @@ the focus or `false` otherwise.
 request_next_widget(container::WidgetContainer) = _next_widget(container)
 
 """
-    function request_prev_widget(container::WidgetContainer)
+    request_prev_widget(container::WidgetContainer)
 
 Request the previous widget in `container`. It returns `true` if a widget has
 get the focus or `false` otherwise.
@@ -225,7 +225,7 @@ end
 ################################################################################
 
 """
-    function _draw_title(container::WidgetContainer)
+    _draw_title(container::WidgetContainer)
 
 Draw the title in the container `container`.
 
@@ -259,7 +259,7 @@ function _draw_title(container::WidgetContainer)
 end
 
 """
-    function _next_widget(container::WidgetContainer)
+    _next_widget(container::WidgetContainer)
 
 Move the focus of container `container` to the next widget.
 
@@ -295,7 +295,7 @@ function _next_widget(container::WidgetContainer)
 end
 
 """
-    function _previous_widget(container::WidgetContainer)
+    _previous_widget(container::WidgetContainer)
 
 Move the focus of container `container` to the previous widget.
 

--- a/src/widgets/input_field.jl
+++ b/src/widgets/input_field.jl
@@ -224,7 +224,7 @@ require_cursor(widget::WidgetInputField) = true
 ################################################################################
 
 """
-    function clear_data!(widget::WidgetInputField)
+    clear_data!(widget::WidgetInputField)
 
 Clear the data in the input field `widget`.
 
@@ -244,7 +244,7 @@ function clear_data!(widget::WidgetInputField)
 end
 
 """
-    function get_data(widget::WidgetInputField)
+    get_data(widget::WidgetInputField)
 
 Get the data of `widget`. If a validator of type `DataType` is provided, then it
 will return the parsed data. Otherwise, it will return a string.

--- a/src/widgets/labels.jl
+++ b/src/widgets/labels.jl
@@ -90,7 +90,7 @@ end
 ################################################################################
 
 """
-    function change_text(widget::WidgetLabel, new_text::AbstractString; alignment = :l, color::Int = -1)
+    change_text(widget::WidgetLabel, new_text::AbstractString; alignment = :l, color::Int = -1)
 
 Change to text of the label widget `widget` to `new_text`.
 

--- a/src/widgets/progress_bar.jl
+++ b/src/widgets/progress_bar.jl
@@ -103,7 +103,7 @@ end
 # ==============================================================================
 
 """
-    function change_value(widget::WidgetProgressBar, new_value::Int; color::Int = -1)
+    change_value(widget::WidgetProgressBar, new_value::Int; color::Int = -1)
 
 Change the value of the progress bar to `new_value`.
 

--- a/src/widgets/radio_button.jl
+++ b/src/widgets/radio_button.jl
@@ -137,7 +137,7 @@ release_focus(widget::WidgetRadioButton) = release_focus(widget.button)
 ################################################################################
 
 """
-    function get_selected(group_name::AbstractString)
+    get_selected(group_name::AbstractString)
 
 Return the `WidgetRadioButton` that is selected in group with name `group_name`.
 If the `group_name` does not exists or if no button is selected, then `nothing`
@@ -164,7 +164,7 @@ end
 ################################################################################
 
 """
-    function _select_radio_button(rb::WidgetRadioButton)
+    _select_radio_button(rb::WidgetRadioButton)
 
 Select the radio button `rb` in its group name.
 
@@ -187,7 +187,7 @@ function _select_radio_button(rb::WidgetRadioButton)
 end
 
 """
-    function _select_radio_button(rb::WidgetRadioButton)
+    _select_radio_button(rb::WidgetRadioButton)
 
 Deselect the radio button `rb` in its group name.
 

--- a/src/widgets/widgets.jl
+++ b/src/widgets/widgets.jl
@@ -14,7 +14,7 @@ export accept_focus, create_widget, destroy_widget, request_update,
        request_focus, redraw, release_focus, update
 
 """
-    function accept_focus(widget)
+    accept_focus(widget)
 
 Return `true` is the widget `widget` accepts focus or `false` otherwise.
 
@@ -22,7 +22,7 @@ Return `true` is the widget `widget` accepts focus or `false` otherwise.
 accept_focus(widget) = return true
 
 """
-    function create_widget(T, parent::Window, begin_y::Int, begin_x::Int, vargs...; kwargs...)
+    create_widget(T, parent::Window, begin_y::Int, begin_x::Int, vargs...; kwargs...)
 
 Create the widget of type `T` in the parent window `parent`. The widget will be
 positioned on the coordinate `(begin_y, begin_x)` of the parent window.
@@ -34,7 +34,7 @@ Additional variables and keywords related to each widget can be passed using
 create_widget
 
 """
-    function destroy_widget(widget; refresh::Bool = true)
+    destroy_widget(widget; refresh::Bool = true)
 
 Destroy the widget `widget`.
 
@@ -46,7 +46,7 @@ destroy_widget(widget; refresh::Bool = true) =
     _destroy_widget(widget; refresh = refresh)
 
 """
-    function get_buffer(widget)
+    get_buffer(widget)
 
 Return the buffer of the widget `widget`.
 
@@ -55,7 +55,7 @@ get_buffer(widget) = widget.common.buffer
 
 
 """
-    function get_parent(widget)
+    get_parent(widget)
 
 Return the parent of the widget `widget`.
 
@@ -63,7 +63,7 @@ Return the parent of the widget `widget`.
 get_parent(widget) = widget.common.parent
 
 """
-    function process_focus(widget, k::Keystroke)
+    process_focus(widget, k::Keystroke)
 
 Process the actions when widget `widget` is in focus and the keystroke `k` is
 pressed. If it returns `false`, then it is means that the widget was not capable
@@ -73,7 +73,7 @@ to process the focus. Otherwise, it must return `true`.
 process_focus(widget,k::Keystroke) = return false
 
 """
-    function request_focus(widget)
+    request_focus(widget)
 
 Request to focus to the widget `widget`.
 
@@ -89,7 +89,7 @@ function request_focus(widget)
 end
 
 """
-    function request_update(widget)
+    request_update(widget)
 
 Request update of the widget `widget`.
 
@@ -101,7 +101,7 @@ function request_update(widget)
 end
 
 """
-    function redraw(widget)
+    redraw(widget)
 
 Redraw the widget inside its content window `cwin`.
 
@@ -109,7 +109,7 @@ Redraw the widget inside its content window `cwin`.
 redraw
 
 """
-    function release_focus(widget)
+    release_focus(widget)
 
 Request focus to be released. It should return `true` if the focus can be
 released or `false` otherwise.
@@ -118,7 +118,7 @@ released or `false` otherwise.
 release_focus(widget) = return true
 
 """
-    function update(widget; force_redraw = false)
+    update(widget; force_redraw = false)
 
 Update the widget by calling the function `redraw`. This function returns `true`
 if the widget needed to be updated of `false` otherwise.
@@ -138,7 +138,7 @@ function update(widget; force_redraw = false)
 end
 
 """
-    function require_cursor()
+    require_cursor()
 
 If `true`, then the physical cursor will be shown and the position will be
 updated according to its position in the widget window. Otherwise, the physical
@@ -163,7 +163,7 @@ request_prev_widget(widget) = accept_focus(widget)
 export create_widget_common
 
 """
-    function create_widget_common(parent::WidgetParent, opc::ObjectPositioningConfiguration)
+    create_widget_common(parent::WidgetParent, opc::ObjectPositioningConfiguration)
 
 Create all the variables in the common structure of the widget API.
 
@@ -200,7 +200,7 @@ end
 ################################################################################
 
 """
-    function _destroy_widget(widget; refresh::Bool = true)
+    _destroy_widget(widget; refresh::Bool = true)
 
 Private function that destroys a widget. This can be used if a new widget needs
 to reimplement the destroy function.

--- a/src/windows/container.jl
+++ b/src/windows/container.jl
@@ -8,7 +8,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #==#
 
 """
-    function add_widget(win::Window, widget::Widget)
+    add_widget(win::Window, widget::Widget)
 
 Add widget `widget` to the window `win`. If the `win` already have a widget,
 then it will be replaced.
@@ -20,7 +20,7 @@ function add_widget(win::Window, widget::Widget)
 end
 
 """
-    function request_focus(win::Window, widget)
+    request_focus(win::Window, widget)
 
 Request the focus to the widget `widget` of the window `win`. This function is
 only necessary to make `Window` comply to the containers API. Since a window can
@@ -37,7 +37,7 @@ function request_focus(win::Window, widget)
 end
 
 """
-    function remove_widget(win::Window, widget::Widget)
+    remove_widget(win::Window, widget::Widget)
 
 Remove the widget `widget` from the window `win`. If `widget` does not belong to
 `win`, then nothing is done.

--- a/src/windows/create_destroy.jl
+++ b/src/windows/create_destroy.jl
@@ -141,7 +141,7 @@ function create_window(id::String = ""; bcols::Int = 0, blines::Int = 0,
 end
 
 """
-    function create_window_with_container(vargs...; kwargs...)
+    create_window_with_container(vargs...; kwargs...)
 
 Create a window with a container as its widget. The arguments and keywords are
 the same ones of the function `create_window`. The container will have the same
@@ -160,7 +160,7 @@ function create_window_with_container(vargs...; kwargs...)
 end
 
 """
-    function destroy_window(win::Window)
+    destroy_window(win::Window)
 
 Destroy the window `win`.
 
@@ -203,7 +203,7 @@ function destroy_window(win::Window)
 end
 
 """
-    function destroy_all_windows()
+    destroy_all_windows()
 
 Destroy all windows managed by the TUI.
 

--- a/src/windows/focus.jl
+++ b/src/windows/focus.jl
@@ -10,7 +10,7 @@ export accept_focus, has_focus, focus_on_widget, next_widget, process_focus,
        previous_widget, sync_cursor
 
 """
-    function accept_focus(window::Window)
+    accept_focus(window::Window)
 
 Check if the window `window` can accept focus and, if it can, then perform the
 actions to change the focus.
@@ -42,7 +42,7 @@ function accept_focus(window::Window)
 end
 
 """
-    function has_focus(window::Window, widget)
+    has_focus(window::Window, widget)
 
 Return `true` if the widget `widget` is in focus on window `window`, or `false`
 otherwise.
@@ -53,7 +53,7 @@ function has_focus(window::Window, widget)
 end
 
 """
-    function process_focus(window::Window, k::Keystroke)
+    process_focus(window::Window, k::Keystroke)
 
 Process the focus on window `window` due to keystroke `k`.
 
@@ -81,7 +81,7 @@ function process_focus(window::Window, k::Keystroke)
 end
 
 """
-    function sync_cursor(window::Window)
+    sync_cursor(window::Window)
 
 Synchronize the cursor to the position of the focused widget in window `window`.
 This is necessary because all the operations are done in the buffer and then

--- a/src/windows/manage.jl
+++ b/src/windows/manage.jl
@@ -9,7 +9,7 @@
 export hide_window, move_window, move_window_to_top, show_window
 
 """
-    function hide_window(win::Window)
+    hide_window(win::Window)
 
 Hide the window `win`.
 
@@ -17,7 +17,7 @@ Hide the window `win`.
 hide_window(win::Window) = hide_panel(win.panel)
 
 """
-    function move_window(win::Window, starty::Int, startx::Int)
+    move_window(win::Window, starty::Int, startx::Int)
 
 Move the window `win` to the position `(starty, startx`).
 
@@ -26,7 +26,7 @@ move_window(win::Window, starty::Int, startx::Int) =
     move_panel(win.panel, starty, startx)
 
 """
-    function move_window_to_top(win::Window)
+    move_window_to_top(win::Window)
 
 Move window `win` to the top.
 
@@ -34,7 +34,7 @@ Move window `win` to the top.
 move_window_to_top(win::Window) = top_panel(win.panel)
 
 """
-    function show_window(win::Window)
+    show_window(win::Window)
 
 Show the window `win`.
 

--- a/src/windows/misc.jl
+++ b/src/windows/misc.jl
@@ -9,7 +9,7 @@
 export get_buffer, set_window_title
 
 """
-    function get_buffer(win::Window)
+    get_buffer(win::Window)
 
 Return the buffer of the window `win`.
 
@@ -17,7 +17,7 @@ Return the buffer of the window `win`.
 get_buffer(win::Window) = win.buffer
 
 """
-    function get_parent(win::Window)
+    get_parent(win::Window)
 
 Return `nothing` since the window has no parent.
 
@@ -25,7 +25,7 @@ Return `nothing` since the window has no parent.
 get_parent(win::Window) = nothing
 
 """
-    function set_window_title(win::Window, title::AbstractString; ...)
+    set_window_title(win::Window, title::AbstractString; ...)
 
 Set the title of the window `win` to `title`.
 
@@ -72,7 +72,7 @@ end
 ################################################################################
 
 """
-    function _get_window_dims(win::Ptr{WINDOW})
+    _get_window_dims(win::Ptr{WINDOW})
 
 Get the dimensions of the window `win` and return it on a tuple `(dim_y,dim_x)`.
 If the window is not initialized, then this function returns `(-1,-1)`.
@@ -90,7 +90,7 @@ function _get_window_dims(win::Ptr{WINDOW})
 end
 
 """
-    function _get_window_cur_pos(win::Ptr{WINDOW})
+    _get_window_cur_pos(win::Ptr{WINDOW})
 
 Get the cursor position of the window `win` and return it on a tuple
 `(cur_y,cur_x)`.  If the window is not initialized, then this function returns

--- a/src/windows/refresh_update.jl
+++ b/src/windows/refresh_update.jl
@@ -10,7 +10,7 @@ export refresh_window, refresh_all_windows, move_view, move_view_inc,
        update_view
 
 """
-    function refresh_window(id::String)
+    refresh_window(id::String)
 
 Refresh the window with id `id` and all its parents windows except for the root
 window.
@@ -23,7 +23,7 @@ function refresh_window(id::String)
 end
 
 """
-    function refresh_window(win::Window; force_redraw = false)
+    refresh_window(win::Window; force_redraw = false)
 
 Refresh the window `win` and its widget. If the view needs to be updated (see
 `view_needs_update`) or if `force_redraw` is `true`, then the content of the
@@ -48,7 +48,7 @@ function refresh_window(win::Window; force_redraw = false)
 end
 
 """
-    function refresh_all_windows()
+    refresh_all_windows()
 
 Refresh all the windows, including the root window.
 
@@ -62,7 +62,7 @@ function refresh_all_windows()
 end
 
 """
-    function request_update(win::Window)
+    request_update(win::Window)
 
 Request update of the window `win` because its widget was updated.
 
@@ -73,7 +73,7 @@ function request_update(win::Window)
 end
 
 """
-    function request_view_update(win::Window)
+    request_view_update(win::Window)
 
 Request to update the view of window `win`. Notice that this must also request
 update on all parent windows until the root window.
@@ -90,7 +90,7 @@ end
 # ==============================================================================
 
 """
-    function move_view(win::Window, y::Int, x::Int; update::Bool = true)
+    move_view(win::Window, y::Int, x::Int; update::Bool = true)
 
 Move the origin of the view of window `win` to the position `(y,x)`. This
 routine makes sure that the view will never reach positions outside the buffer.
@@ -121,7 +121,7 @@ function move_view(win::Window, y::Int, x::Int; update::Bool = true)
 end
 
 """
-    function move_view_inc(win::Window; Δy::Int, Δx::Int; kwargs...)
+    move_view_inc(win::Window; Δy::Int, Δx::Int; kwargs...)
 
 Move the view of the window `win` to the position `(y+Δy, x+Δx)`. This function
 has the same set of keywords of the function `move_view`.
@@ -131,7 +131,7 @@ move_view_inc(win::Window, Δy::Int, Δx::Int; kwargs...) =
     move_view(win, win.orig[1]+Δy, win.orig[2]+Δx; kwargs...)
 
 """
-    function update_view(win::Window; force::Bool = false)
+    update_view(win::Window; force::Bool = false)
 
 Update the view of window `win` by copying the contents from the buffer. If the
 view does not need to be updated (see `view_needs_update`), then nothing is


### PR DESCRIPTION
Generally in docstrings, we just put the signature at the top (i.e. name + arguments, like `foo(x::Int, y::String)`). I removed the `function` prefix from them.
Also, in places where there were multiple `@eval`s, I combined them into one `@eval` block. I thought it might result in faster loading, but it was like a 0.05 second difference. In any case, I think it's a bit cleaner.