### PR TITLE
RFC: Poll `wgetch` to avoid blocking other tasks.

### DIFF
--- a/src/colors.jl
+++ b/src/colors.jl
@@ -70,7 +70,7 @@ function ncurses_color(attrs::Integer = 0;
     attrs |= bold ? A_BOLD : 0
     attrs |= underline ? A_UNDERLINE : 0
 
-    return attrs
+    return signed(attrs)
 end
 
 """

--- a/src/input/input.jl
+++ b/src/input/input.jl
@@ -34,7 +34,7 @@ function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
     nodelay(win_ptr, true)
     c_raw = wgetch(win_ptr)
     while c_raw < 0
-        sleep(0.1)
+        wait(RawFD(Base.STDIN_NO);readable=true)
         c_raw = wgetch(win_ptr)
     end
 

--- a/src/input/input.jl
+++ b/src/input/input.jl
@@ -29,7 +29,14 @@ listen for the keystroke.
 
 """
 function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
-    c_raw = (win == nothing) ? getch() : wgetch(win)
+
+    win_ptr = (win == nothing) ? tui.stdscr : win
+    nodelay(win_ptr, true)
+    c_raw = wgetch(win_ptr)
+    while c_raw < 0
+        sleep(0.1)
+        c_raw = wgetch(win_ptr)
+    end
 
     c_raw < 0 && return Keystroke(raw = c_raw, value = "ERR", ktype = :undefined)
 
@@ -43,7 +50,7 @@ function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
         # Here, we need to read a sequence of characters that is already in the
         # buffer. Thus, we will disable the delay.
         win_ptr = (win == nothing) ? tui.stdscr : win
-        nodelay(win_ptr, true)
+        #nodelay(win_ptr, true)
 
         # Read the entire sequence limited to 10 characters.
         for i = 1:10
@@ -54,7 +61,7 @@ function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
         end
 
         # Re-enable the delay.
-        nodelay(win_ptr, false)
+        #nodelay(win_ptr, false)
 
         if length(s) == 1
             return Keystroke(raw = c, value = s, ktype = :esc)

--- a/src/input/input.jl
+++ b/src/input/input.jl
@@ -33,7 +33,7 @@ function jlgetch(win::Union{Ptr{WINDOW},Nothing} = nothing)
     win_ptr = (win == nothing) ? tui.stdscr : win
     nodelay(win_ptr, true)
     c_raw = wgetch(win_ptr)
-    while c_raw < 0
+    while c_raw < 0 && isopen(stdin)
         wait(RawFD(Base.STDIN_NO);readable=true)
         c_raw = wgetch(win_ptr)
     end


### PR DESCRIPTION
The current `wgetch` (and `getch`) functions are blocking.
This means that while the main loop is waiting for a character, none of the other Julia Tasks will run.

In the example below, the `@async` loop never runs because it is stuck waiting inside `take!` while the main loop is stuck waiting for a keypress in `wgetch`.

```julia
@async while true
    data = take!(sensor_data_channel)
    change_text(mylabel, data)
end

app_main_loop()
```

The patch in this PR sets `nodelay(win_ptr, true)` to make `wgetch` non-blocking, then calls `sleep` in a loop to give other tasks a chance to run.

I have a feeling that there must be a better way to solve this problem. But this works for me.
I tried using [@threadcall](https://docs.julialang.org/en/v1/base/multi-threading/#Base.@threadcall) and I tried using [@spawn](https://docs.julialang.org/en/v1/base/multi-threading/#Base.Threads.@spawn) + a pair of Channels, but neither of these worked smoothly. I suspect that something about ncurses and libuv both waiting for IO doesn't work properly. (Julia waits for linuv [here](https://github.com/JuliaLang/julia/blob/0a77e07c4d964bcec172bde2918097111814a07e/src/jl_uv.c#L206-L220)).

[update: 2nd commit uses `wait(RawFD` instead of polling with sleep.]
