### PR TITLE
new functions and constants for Vdiff

### DIFF
--- a/src/submodules/NCurses/ncurses_functions.jl
+++ b/src/submodules/NCurses/ncurses_functions.jl
@@ -57,6 +57,13 @@ end
 for (f, r, v, j, c) in
     (
         (
+            :beep,
+            Cint,
+            [],
+            [],
+            []
+        ),
+        (
             :can_change_color,
             Cbool,
             [],
@@ -65,7 +72,7 @@ for (f, r, v, j, c) in
         ),
         (
             :cbreak,
-            Cvoid,
+            Cint,
             [],
             [],
             []
@@ -86,6 +93,13 @@ for (f, r, v, j, c) in
         ),
         (
             :clrtoeol,
+            Cint,
+            [],
+            [],
+            []
+        ),
+        (
+            :def_prog_mode,
             Cint,
             [],
             [],
@@ -169,11 +183,25 @@ for (f, r, v, j, c) in
             ["Ptr{WINDOW}"]
         ),
         (
+            :getmouse,
+            Cint,
+            ["event"],
+            ["Ptr{MEVENT}"],
+            ["Ptr{MEVENT}"]
+        ),
+        (
             :has_colors,
             Cbool,
             [],
             [],
             []
+        ),
+        (
+            :winch,
+            Cint,
+            ["win"],
+            ["Ptr{WINDOW}"],
+            ["Ptr{WINDOW}"]
         ),
         (
             :initscr,
@@ -197,11 +225,11 @@ for (f, r, v, j, c) in
             ["Ptr{WINDOW}", "Cuchar"]
         ),
         (
-            :scrollok,
-            Cvoid,
-            ["win", "bf"],
-            ["Ptr{WINDOW}", "Bool"],
-            ["Ptr{WINDOW}", "Cuchar"]
+            :mousemask,
+            Culong,
+            ["newmask", "oldmask"],
+            ["UInt", "Ptr{UInt}"],
+            ["Culong", "Ptr{Culong}"]
         ),
         (
             :nodelay,
@@ -225,11 +253,32 @@ for (f, r, v, j, c) in
             ["Ptr{WINDOW}", "Cuchar"]
         ),
         (
+            :overwrite,
+            Cint,
+            ["scr", "dest"],
+            ["Ptr{WINDOW}", "Ptr{WINDOW}"],
+            ["Ptr{WINDOW}", "Ptr{WINDOW}"]
+        ),
+        (
             :refresh,
             Cvoid,
             [],
             [],
             []
+        ),
+        (
+            :reset_prog_mode,
+            Cint,
+            [],
+            [],
+            []
+        ),
+        (
+            :scrollok,
+            Cvoid,
+            ["win", "bf"],
+            ["Ptr{WINDOW}", "Bool"],
+            ["Ptr{WINDOW}", "Cuchar"]
         ),
         (
             :start_color,
@@ -360,6 +409,13 @@ for (f, r, v, j, c) in
             ["win", "nlines", "ncols", "begin_y", "begin_x"],
             ["Ptr{WINDOW}", ["T" for _ = 1:4]...],
             ["Ptr{WINDOW}", ["Cint" for _ = 1:4]...]
+        ),
+        (
+            :halfdelay,
+            Cint,
+            ["tenths"],
+            ["T"],
+            ["Cint"]
         ),
         (
             :init_color,
@@ -691,6 +747,20 @@ for (f, r, v, j, c) in
         ),
         (
             :printw,
+            Cvoid,
+            ["str"],
+            ["T"],
+            ["Cstring"]
+        ),
+        (
+            :waddstr,
+            Cvoid,
+            ["win", "str"],
+            ["Ptr{WINDOW}", "T"],
+            ["Ptr{WINDOW}", "Cstring"]
+        ),
+        (
+            :addstr,
             Cvoid,
             ["str"],
             ["T"],

--- a/src/submodules/NCurses/ncurses_keys.jl
+++ b/src/submodules/NCurses/ncurses_keys.jl
@@ -1,0 +1,47 @@
+## Description #################################################################
+#
+# This file contains the definition of keys in libncurses.
+#
+################################################################################
+
+KEY_CTRL(c::Char)=UInt8(c-'A'+1)
+const KEY_DOWN=0o402
+const KEY_LEFT=0o404
+const KEY_UP=0o403
+const KEY_RIGHT=0o405
+const KEY_HOME=0o406
+const KEY_BACKSPACE=0o407
+KEY_F(i)=0o410+i
+const KEY_DC=0o512
+const KEY_IC=0o513
+const KEY_SF=0o520
+const KEY_SR=0o521
+const KEY_NPAGE=0o522
+const KEY_PPAGE=0o523
+const KEY_ENTER=0o527
+const KEY_BTAB=0o541
+const KEY_BEG=0o542
+const KEY_END=0o550
+const KEY_SDELETE=0o577
+const KEY_SEND=0o602
+const KEY_SHOME=0o607
+const KEY_SIC=0o610
+const KEY_SLEFT=0o611
+const KEY_SNEXT=0o614
+const KEY_SPREVIOUS=0o616
+const KEY_SRIGHT=0o622
+const KEY_MOUSE=0o631
+KEY_ALT(c::Char)=0o641+c-'A'
+const KEY_CTRL_DC=0o1020
+const KEY_CTRL_DOWN=0o1026
+const KEY_CTRL_END=0o1033
+const KEY_CTRL_LEFT=0o1052
+const KEY_CTRL_HOME=0o1040
+const KEY_CTRL_NPAGE=0o1057
+const KEY_CTRL_PPAGE=0o1064
+const KEY_CTRL_RIGHT=0o1071
+const KEY_CTRL_UP=0o1077
+const KEY_PAD_PLUS=0o1107
+const KEY_PAD_DIV=0o1111
+const KEY_PAD_TIMES=0o1113
+const KEY_PAD_MINUS=0o1114

--- a/src/submodules/NCurses/ncurses_mouse.jl
+++ b/src/submodules/NCurses/ncurses_mouse.jl
@@ -1,0 +1,52 @@
+## Description #################################################################
+#
+# This file contains the definition of mouse events in libncurses.
+#
+################################################################################
+
+"""
+    struct MEVENT
+
+represents a mouse event
+
+"""
+mutable struct MEVENT
+    id::Cshort
+    x::Cint
+    y::Cint
+    z::Cint
+    bstate::Culong
+end
+
+NCURSES_MOUSE_MASK(b,m)=m<<((b-1)*6)
+const NCURSES_BUTTON_RELEASED=1
+const NCURSES_BUTTON_PRESSED=2
+const NCURSES_BUTTON_CLICKED=4
+const NCURSES_DOUBLE_CLICKED=8
+
+const BUTTON1_RELEASED=       NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_RELEASED)
+const BUTTON1_PRESSED=        NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_PRESSED)
+const BUTTON1_CLICKED=        NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_CLICKED)
+const BUTTON1_DOUBLE_CLICKED= NCURSES_MOUSE_MASK(1, NCURSES_DOUBLE_CLICKED)
+const BUTTON2_RELEASED=       NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_RELEASED)
+const BUTTON2_PRESSED=        NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_PRESSED)
+const BUTTON2_CLICKED=        NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_CLICKED)
+const BUTTON2_DOUBLE_CLICKED= NCURSES_MOUSE_MASK(2, NCURSES_DOUBLE_CLICKED)
+const BUTTON3_RELEASED=       NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_RELEASED)
+const BUTTON3_PRESSED=        NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_PRESSED)
+const BUTTON3_CLICKED=        NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_CLICKED)
+const BUTTON3_DOUBLE_CLICKED= NCURSES_MOUSE_MASK(3, NCURSES_DOUBLE_CLICKED)
+const REPORT_MOUSE_POSITION=  NCURSES_MOUSE_MASK(6, 10)
+const ALL_MOUSE_EVENTS=       REPORT_MOUSE_POSITION-1
+
+# two useful methods which also show the proper use of
+# getmouse and mousemask
+
+function getmouse() 
+  me=MEVENT(1,0,0,0,0)
+  getmouse(Ptr{MEVENT}(pointer_from_objref(me)))
+  me
+end
+
+mousemask(x::Integer)=mousemask(UInt(x),Ptr{UInt}(C_NULL))
+

--- a/src/submodules/NCurses/types.jl
+++ b/src/submodules/NCurses/types.jl
@@ -44,6 +44,8 @@ const ncurses = NCURSES()
 
 include("ncurses_types.jl")
 include("ncurses_attributes.jl")
+include("ncurses_keys.jl")
+include("ncurses_mouse.jl")
 include("./form/form_types.jl")
 include("./menu/menu_types.jl")
 include("./panel/panel_types.jl")


### PR DESCRIPTION
Hello, thanks to your nice port of `NCurses` I have written a console application 
```
https://github.com/jmichel7/Vdiff.jl
```
Along the way I had to add the curses functions 

beep, def_prog_mode, reset_prog_mode, getmouse, mousemask, winch, overwrite, halfdelay, waddstr, addstr

I added also some constants defined in ncurses:

-the file `ncurses_mouse.jl` contains the definition of the `struct M̀EVENT` and of the constants used for mouse states.

-the file `ncurses_keys.jl` contains some of the key definitions in `libncurses`, to which I have added functions `KEY_CTRL` and `KEY_ALT`

You will need to use a version of `TextUserInterfaces` incorporating the above changes if you want to try `Vdiff`.
 Thank you again for your package!